### PR TITLE
fix: consume sign changing item when not in creative

### DIFF
--- a/src/main/java/com/ivanff/improvedSigns/event/UseSignBlockCallback.java
+++ b/src/main/java/com/ivanff/improvedSigns/event/UseSignBlockCallback.java
@@ -20,6 +20,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.Stats;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -27,6 +28,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.event.GameEvent;
 
 public class UseSignBlockCallback {
     public static ActionResult onUseSignBlockCallback(PlayerEntity player, World world, Hand hand,
@@ -72,7 +74,13 @@ public class UseSignBlockCallback {
         }
 
         BlockState bs = world.getBlockState(pos);
-        if (player.getStackInHand(Hand.MAIN_HAND).getItem() instanceof SignChangingItem signChangingItem && signChangingItem.canUseOnSignText(signText, player) && signChangingItem.useOnSign(world, signBlockEntity, front, player)) {
+        ItemStack handItem = player.getStackInHand(Hand.MAIN_HAND);
+        if (handItem.getItem() instanceof SignChangingItem signChangingItem && signChangingItem.canUseOnSignText(signText, player) && signChangingItem.useOnSign(world, signBlockEntity, front, player)) {
+            if (!player.isCreative()) {
+                handItem.decrement(1);
+            }
+            world.emitGameEvent(GameEvent.BLOCK_CHANGE, signBlockEntity.getPos(), GameEvent.Emitter.of(player, signBlockEntity.getCachedState()));
+            player.incrementStat(Stats.USED.getOrCreateStat(handItem.getItem()));
             return ActionResult.SUCCESS;
         }
 

--- a/src/main/java/com/ivanff/improvedSigns/mixin/AbstractSignBlockMixin.java
+++ b/src/main/java/com/ivanff/improvedSigns/mixin/AbstractSignBlockMixin.java
@@ -8,8 +8,6 @@ import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.text.Text;
-import net.minecraft.util.DyeColor;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
Apologies, this is a case that I missed