### PR TITLE
update: 1.20.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,21 @@
 org.gradle.jvmargs   = -Xmx1G
 
 #Fabric properties 
-minecraft_version    = 1.20.5
-yarn_mappings        = 1.20.5+build.1
-loader_version       = 0.15.10
+minecraft_version    = 1.20.6
+yarn_mappings        = 1.20.6+build.1
+loader_version       = 0.15.11
 
 #Mod properties 
-mod_version          = 1.4.0
+mod_version          = 1.4.1
 maven_group          = com.craftycorvid.improvedSigns
 archives_base_name   = improvedsigns
 
 #Dependencies
-fabric_api_version   = 0.97.6+1.20.5
-midnightlib_version  = 1.5.4-fabric
+fabric_api_version   = 0.98.0+1.20.6
+midnightlib_version  = 1.5.5-fabric
 modmenu_version      = 10.0.0-beta.1
 
 #Distribution
 curseforge_id        = 384963
 modrinth_id          = tEcCNQe7
-changelog            = Updated to 1.20.5
+changelog            = Updated to 1.20.6

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,6 @@
   "depends": {
     "fabricloader": ">=0.15.10",
     "fabric": "*",
-    "minecraft": ["1.20.5"]
+    "minecraft": ["1.20.5", "1.20.6"]
   }
 }


### PR DESCRIPTION
just change the embedded version of midnightconfig and push the versions, still compatible with 1.20.5.